### PR TITLE
Text to speech functionality

### DIFF
--- a/Capstone/Capstone.csproj
+++ b/Capstone/Capstone.csproj
@@ -135,6 +135,7 @@
       <DependentUpon>App.xaml</DependentUpon>
     </Compile>
     <Compile Include="Common\StringUtils.cs" />
+    <Compile Include="Common\TextToSpeechEngine.cs" />
     <Compile Include="Common\UIUtils.cs" />
     <Compile Include="DataPrivacyTips.xaml.cs">
       <DependentUpon>DataPrivacyTips.xaml</DependentUpon>

--- a/Capstone/Capstone.csproj
+++ b/Capstone/Capstone.csproj
@@ -169,7 +169,7 @@
     </AppxManifest>
   </ItemGroup>
   <ItemGroup>
-    <Content Include="InitialScript.sql" />
+    <Content Include="Database\InitialScript.sql" />
     <Content Include="Properties\Default.rd.xml" />
     <Content Include="Assets\LockScreenLogo.scale-200.png" />
     <Content Include="Assets\SplashScreen.scale-200.png" />

--- a/Capstone/Common/TextToSpeechEngine.cs
+++ b/Capstone/Common/TextToSpeechEngine.cs
@@ -49,7 +49,7 @@ namespace Capstone.Common
 
         public SSMLBuilder Break(int duration = 0)
         {
-            this.ssmlText += $"<break {(duration > 0 ? $"time='{duration}'" : "")}/>";
+            this.ssmlText += $"<break {(duration > 0 ? $"time='{duration}' " : "")}/>";
             return this;
         }
 
@@ -67,7 +67,7 @@ namespace Capstone.Common
 
         public SSMLBuilder Prosody(string text, string pitch = "", string contour = "", string range = "", string rate = "", string duration = "")
         {
-            this.ssmlText += $"<prosody {(pitch.Length > 0 ? $"pitch='{pitch}'" : "")} {(contour.Length > 0 ? $"contour='{contour}'" : "")} {(range.Length > 0 ? $"range='{range}'" : "")} {(rate.Length > 0 ? $"rate='{rate}'" : "")} {(duration.Length > 0 ? $"duration='{duration}'" : "")}>{text}</prosody>";
+            this.ssmlText += $"<prosody{(pitch.Length > 0 ? $" pitch='{pitch}'" : "")}{(contour.Length > 0 ? $" contour='{contour}'" : "")}{(range.Length > 0 ? $" range='{range}'" : "")}{(rate.Length > 0 ? $" rate='{rate}'" : "")}{(duration.Length > 0 ? $" duration='{duration}'" : "")}>{text}</prosody>";
             return this;
         }
 

--- a/Capstone/Common/TextToSpeechEngine.cs
+++ b/Capstone/Common/TextToSpeechEngine.cs
@@ -78,6 +78,12 @@ namespace Capstone.Common
             return this;
         }
 
+        public SSMLBuilder Sub(string text, string substitute)
+        {
+            this.ssmlText += $"<sub alias='{substitute}'>{text}</sub>";
+            return this;
+        }
+
         public enum SayAsTypes
         {
             ADDRESS = 0,

--- a/Capstone/Common/TextToSpeechEngine.cs
+++ b/Capstone/Common/TextToSpeechEngine.cs
@@ -7,130 +7,28 @@ namespace Capstone.Common
     public static class TextToSpeechEngine
     {
         /// <summary>
-        /// Allows for speaking uninflected text in the windows default voice.
+        /// Speaks the passed text in an uninflected voice through the passed MediaElement
         /// </summary>
-        /// <param name="media">A MediaElement, likely one hidden on the page somewhere</param>
-        /// <param name="textToSpeak">The text you want spoken</param>
-        public static async void SpeakText(MediaElement media, string textToSpeak)
+        /// <param name="media"> the media element on the page to play the sound through</param>
+        /// <param name="text">the text to speak</param>
+        public static async void SpeakText(MediaElement media, string text)
         {
-            // create the synthesizer
-            var synthesizer = new SpeechSynthesizer();
-            // synthesize the text and create a stream from it
-            SpeechSynthesisStream stream = await synthesizer.SynthesizeTextToStreamAsync(textToSpeak);
-            // prepare our media to output the stream and then output it
+            var synth = new SpeechSynthesizer();
+            // create the audio stream from our text
+            SpeechSynthesisStream stream = await synth.SynthesizeTextToStreamAsync(text);
+            // prepare the media object to speak and play the audio
             media.SetSource(stream, stream.ContentType);
             media.Play();
         }
 
-        public static async void SpeakInflectedText(MediaElement media, string ssmlTextToSpeak)
+        public static async void SpeakSSMLText(MediaElement media, string ssmlText)
         {
-            var synthesizer = new SpeechSynthesizer();
-            SpeechSynthesisStream stream = await synthesizer.SynthesizeSsmlToStreamAsync(ssmlTextToSpeak);
+            var synth = new SpeechSynthesizer();
+            // create the audio stream from our text
+            SpeechSynthesisStream stream = await synth.SynthesizeSsmlToStreamAsync(ssmlText);
+            // prepare the media object to speak and play the audio
             media.SetSource(stream, stream.ContentType);
             media.Play();
-        }
-    }
-
-    public class SSMLBuilder
-    {
-        public string ssmlText { get; private set; } = "";
-
-        public SSMLBuilder()
-        {
-            this.ssmlText = "<speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis' xml:lang='en-US'>";
-        }
-
-        private SSMLBuilder CloseSSMLText()
-        {
-            this.ssmlText += "</speak>";
-            return this;
-        }
-
-        public SSMLBuilder Sentence(string sentence)
-        {
-            this.ssmlText += $"<sentence>{sentence}</sentence>";
-            return this;
-        }
-
-        public SSMLBuilder Paragraph(string text)
-        {
-            this.ssmlText += $"<p>{text}</p>";
-            return this;
-        }
-
-        public SSMLBuilder Break(int amount = 0)
-        {
-            this.ssmlText += $"<break {(amount > 0 ? $"time='{amount}'" : "")}/>";
-            return this;
-        }
-
-        public SSMLBuilder Prosody(string text, string pitch = "", string contour = "", string range = "", string rate = "", string duration = "")
-        {
-            this.ssmlText += $"<prosody {(pitch.Length > 0 ? $"pitch='{pitch}'" : "")} {(contour.Length > 0 ? $"contour='{contour}'" : "")} {(range.Length > 0 ? $"range='{range}'" : "")} {(duration.Length > 0 ? $"duration='{duration}'" : "")}>{text}</prosody>";
-            return this;
-        }
-
-        public SSMLBuilder SayAs(string text, SayAsTypes type)
-        {
-            // convert the type to a string value
-            string sayAsType = null;
-            switch (type)
-            {
-                case SayAsTypes.ADDRESS:
-                    sayAsType = "address";
-                    break;
-                case SayAsTypes.CARDINAL:
-                    sayAsType = "cardinal";
-                    break;
-                case SayAsTypes.CHARACTERS:
-                    sayAsType = "characters";
-                    break;
-                case SayAsTypes.DATE:
-                    sayAsType = "date";
-                    break;
-                case SayAsTypes.DIGITS:
-                    sayAsType = "digits";
-                    break;
-                case SayAsTypes.FRACTION:
-                    sayAsType = "fraction";
-                    break;
-                case SayAsTypes.ORDINAL:
-                    sayAsType = "ordinal";
-                    break;
-                case SayAsTypes.TELEPHONE:
-                    sayAsType = "telephone";
-                    break;
-                case SayAsTypes.TIME:
-                    sayAsType = "time";
-                    break;
-            }
-            this.ssmlText += $"<say-as interpret-as='{sayAsType}'>{text}</say-as>";
-            return this;
-        }
-
-        public SSMLBuilder Sub(string text, string substitute)
-        {
-            this.ssmlText += $"<sub alias='{substitute}'>{text}</sub>";
-            return this;
-        }
-
-        public string Build()
-        {
-            this.CloseSSMLText();
-            return this.ssmlText;
-        }
-
-        public enum SayAsTypes
-        {
-            ADDRESS = 0,
-            CARDINAL = 1,
-            CHARACTERS = 2,
-            DATE = 3,
-            DIGITS = 4,
-            FRACTION = 5,
-            ORDINAL = 6,
-            TELEPHONE = 7,
-            TIME = 8
         }
     }
 }

--- a/Capstone/Common/TextToSpeechEngine.cs
+++ b/Capstone/Common/TextToSpeechEngine.cs
@@ -76,6 +76,16 @@ namespace Capstone.Common
             return this;
         }
 
+        /// <summary>
+        /// This is where the vocal inflections take place. It's a little complicated, and <a href="https://docs.microsoft.com/en-us/cortana/skills/speech-synthesis-markup-language#prosody-element">Microsoft's documentation</a> does a good job explaining it.
+        /// </summary>
+        /// <param name="text"></param>
+        /// <param name="pitch"></param>
+        /// <param name="contour"></param>
+        /// <param name="range"></param>
+        /// <param name="rate"></param>
+        /// <param name="duration"></param>
+        /// <returns></returns>
         public SSMLBuilder Prosody(string text, string pitch = "", string contour = "", string range = "", string rate = "", string duration = "")
         {
             this.ssmlText += $"<prosody{(pitch.Length > 0 ? $" pitch='{pitch}'" : "")}{(contour.Length > 0 ? $" contour='{contour}'" : "")}{(range.Length > 0 ? $" range='{range}'" : "")}{(rate.Length > 0 ? $" rate='{rate}'" : "")}{(duration.Length > 0 ? $" duration='{duration}'" : "")}>{text}</prosody>";

--- a/Capstone/Common/TextToSpeechEngine.cs
+++ b/Capstone/Common/TextToSpeechEngine.cs
@@ -31,4 +31,64 @@ namespace Capstone.Common
             media.Play();
         }
     }
+
+    public class SSMLBuilder
+    {
+        public string ssmlText { get; private set; } = "";
+
+        public SSMLBuilder()
+        {
+            this.ssmlText = "<speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis' xml:lang='en-US'>";
+        }
+
+        public string Build()
+        {
+            this.ssmlText += "</speak>";
+            return this.ssmlText;
+        }
+
+        public SSMLBuilder Break(int duration = 0)
+        {
+            this.ssmlText += $"<break {(duration > 0 ? $"time='{duration}'" : "")}/>";
+            return this;
+        }
+
+        public SSMLBuilder Sentence(string text)
+        {
+            this.ssmlText += $"<sentence>{text}</sentence>";
+            return this;
+        }
+
+        public SSMLBuilder Paragraph(string text)
+        {
+            this.ssmlText += $"<p>{text}</p>";
+            return this;
+        }
+
+        public SSMLBuilder Prosody(string text, string pitch = "", string contour = "", string range = "", string rate = "", string duration = "")
+        {
+            this.ssmlText += $"<prosody {(pitch.Length > 0 ? $"pitch='{pitch}'" : "")} {(contour.Length > 0 ? $"contour='{contour}'" : "")} {(range.Length > 0 ? $"range='{range}'" : "")} {(rate.Length > 0 ? $"rate='{rate}'" : "")} {(duration.Length > 0 ? $"duration='{duration}'" : "")}>{text}</prosody>";
+            return this;
+        }
+
+        public SSMLBuilder SayAs(string text, SayAsTypes type)
+        {
+            string sayType = Enum.GetName(typeof(SayAsTypes), type).ToLower();
+            this.ssmlText += $"<say-as interpret-as='{sayType}'>{text}</say-as>";
+            return this;
+        }
+
+        public enum SayAsTypes
+        {
+            ADDRESS = 0,
+            CARDINAL = 1,
+            CHARACTERS = 2,
+            DATE = 3,
+            DIGITS = 4,
+            FRACTION = 5,
+            ORDINAL = 6,
+            TELEPHONE = 7,
+            TIME = 8
+        }
+    }
 }

--- a/Capstone/Common/TextToSpeechEngine.cs
+++ b/Capstone/Common/TextToSpeechEngine.cs
@@ -21,7 +21,13 @@ namespace Capstone.Common
             media.Play();
         }
 
-        public static async void SpeakSSMLText(MediaElement media, string ssmlText)
+        /// <summary>
+        /// Speaks text with inflections. The inflections are defined in an xml-like format called SSML (Speech Synthesis Markup Language). To learn more, go to
+        /// <a href="https://docs.microsoft.com/en-us/cortana/skills/speech-synthesis-markup-language">this documentation link</a>
+        /// </summary>
+        /// <param name="media">The media element to speak the text through</param>
+        /// <param name="ssmlText"> the SSML markup to provide inflection data and the words to speak</param>
+        public static async void SpeakInflectedText(MediaElement media, string ssmlText)
         {
             var synth = new SpeechSynthesizer();
             // create the audio stream from our text
@@ -32,6 +38,11 @@ namespace Capstone.Common
         }
     }
 
+    /// <summary>
+    /// A builder class to build a syntactically valid SSML markup string to be used in <see cref="TextToSpeechEngine.SpeakInflectedText(MediaElement, string)"/>.
+    /// <br />
+    /// To learn more about SSML, go to <a href="https://docs.microsoft.com/en-us/cortana/skills/speech-synthesis-markup-language">this documentation link provided by Mircosoft</a>
+    /// </summary>
     public class SSMLBuilder
     {
         public string ssmlText { get; private set; } = "";

--- a/Capstone/MainPage.xaml
+++ b/Capstone/MainPage.xaml
@@ -41,6 +41,6 @@
         <!--the width for now is just temporary. It will be overridden in code-->
         <Canvas x:Name="DynamicArea" Grid.Row="1" Grid.Column="1" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Width="900" Margin="25,0,25,0"></Canvas>
         <TextBox Grid.Row="2" Grid.Column="1" x:Name="CommandBox" Margin="25" Text="" TextWrapping="Wrap" PlaceholderText="Type a command for Bob to do, or question for him to answer" Height="32" VerticalAlignment="Top"/>
-
+        <MediaElement x:Name="media" Visibility="Collapsed"/>
     </Grid>
 </Page>

--- a/Capstone/MainPage.xaml.cs
+++ b/Capstone/MainPage.xaml.cs
@@ -1,4 +1,5 @@
-﻿using Windows.UI.Xaml;
+﻿using Capstone.Common;
+using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
 
@@ -15,15 +16,18 @@ namespace Capstone
             this.InitializeComponent();
             // hide the main menu
             this.MenuColumn.Width = new GridLength(0);
+            string ssmlText = new SSMLBuilder().Sentence("Hello, World!").Prosody("This is some prosody", contour: "(50%,+20%) (90%,-30%)").SayAs("6720 Wesselman Rd. Cleves, OH 45002", SSMLBuilder.SayAsTypes.ADDRESS).Build();
+            TextToSpeechEngine.SpeakSSMLText(this.media, ssmlText);
         }
 
         private void MenuButton_OnClick(object sender, RoutedEventArgs e)
         {
-            if(!this.IsMenuExpanded)
+            if (!this.IsMenuExpanded)
             {
                 // show the menu column
                 this.MenuColumn.Width = new GridLength(320);
-            } else
+            }
+            else
             {
                 this.MenuColumn.Width = new GridLength(0);
             }

--- a/Capstone/MainPage.xaml.cs
+++ b/Capstone/MainPage.xaml.cs
@@ -16,8 +16,6 @@ namespace Capstone
             this.InitializeComponent();
             // hide the main menu
             this.MenuColumn.Width = new GridLength(0);
-            string ssmlText = new SSMLBuilder().Sentence("Hello, World!").Prosody("This is some prosody", contour: "(50%,+20%) (90%,-30%)").SayAs("6720 Wesselman Rd. Cleves, OH 45002", SSMLBuilder.SayAsTypes.ADDRESS).Build();
-            TextToSpeechEngine.SpeakSSMLText(this.media, ssmlText);
         }
 
         private void MenuButton_OnClick(object sender, RoutedEventArgs e)

--- a/UnitTests/SSMLBuilderTests.cs
+++ b/UnitTests/SSMLBuilderTests.cs
@@ -1,0 +1,56 @@
+﻿using Capstone.Common;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace UnitTests
+{
+    [TestClass]
+    public class SSMLBuilderTests
+    {
+        [TestMethod]
+        public void TestNoOptionsBuildsSpeakElement()
+        {
+            string builtText = new SSMLBuilder().Build();
+            Assert.AreEqual("<speak version='1.0' xmlns='http://www.w3.org/2001/10/synthesis' xml:lang='en-US'></speak>", builtText);
+        }
+
+        [TestMethod]
+        public void TestSentenceCreatesSentenceElement()
+        {
+            string builtText = new SSMLBuilder().Sentence("test").Build();
+            Assert.IsTrue(builtText.Contains("<sentence>test</sentence>"));
+        }
+
+        [TestMethod]
+        public void TestBreakCreatesBreakElement()
+        {
+            // essentially 2 different tests
+            Assert.IsTrue(new SSMLBuilder().Break().Build().Contains("<break />"));
+            Assert.IsTrue(new SSMLBuilder().Break(1).Build().Contains("<break time='1' />"));
+        }
+
+        [TestMethod]
+        public void TestParagraphBuildsParagraphElement()
+        {
+            Assert.IsTrue(new SSMLBuilder().Paragraph("test").Build().Contains("<p>test</p>"));
+        }
+
+        [TestMethod]
+        public void TestProsodyBuildsProsodyElement()
+        {
+            Assert.IsTrue(new SSMLBuilder().Prosody("test").Build().Contains("<prosody>test</prosody>"));
+            Assert.IsTrue(new SSMLBuilder().Prosody("test", pitch: "pitch", contour: "contour", range: "range", rate: "rate").Build().Contains("<prosody pitch='pitch' contour='contour' range='range' rate='rate'>test</prosody>"));
+        }
+
+        [TestMethod]
+        public void TestSayAsBuildsSayAsElement()
+        {
+            Assert.IsTrue(new SSMLBuilder().SayAs("123 main street, New York City, NY 12345", SSMLBuilder.SayAsTypes.ADDRESS).Build().Contains("<say-as interpret-as='address'>123 main street, New York City, NY 12345</say-as>"));
+        }
+
+        [TestMethod]
+        public void TestSubBuidlsSubElement()
+        {
+            Assert.IsTrue(new SSMLBuilder().Sub("JVM", "Java Virtual Machine").Build().Contains("<sub alias='Java Virtual Machine'>JVM</sub>"));
+        }
+    }
+}

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -123,6 +123,7 @@
     <Compile Include="AlarmsFormPageTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RemindersFormPageTests.cs" />
+    <Compile Include="SSMLBuilderTests.cs" />
     <Compile Include="StringUtilsTests.cs" />
     <Compile Include="UnitTestApp.xaml.cs">
       <DependentUpon>UnitTestApp.xaml</DependentUpon>


### PR DESCRIPTION
## Additions
- `TextToSpeehEngine` - a static class that can speak text through a page's `MediaElement` through either inflected voice patterns directed by `SSML`, or uninflected voice with plain text
- `SSMLBuilder` - a builder class to build syntactically valid SSML markup to be used with the `TextToSpeechEngine` class.
- unit tests for the `SSMLBuilder` class

## Changes
- added a `MediaElement` object to the main page and marked it as hidden. This will allow bob to speak on the main page through the `TextToSpeechEngine`